### PR TITLE
Fix cipher / decipher update methods, add pbdkf2 sync method onto Crypto

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import sbt._
 
 import scala.language.postfixOps
 
-val apiVersion = "0.3.0.3"
+val apiVersion = "0.3.0.4-SNAPSHOT"
 val scalaJsVersion = "2.12.1"
 
 organization := "io.scalajs"

--- a/nodejs/src/main/scala/io/scalajs/nodejs/crypto/Cipher.scala
+++ b/nodejs/src/main/scala/io/scalajs/nodejs/crypto/Cipher.scala
@@ -71,7 +71,7 @@ trait Cipher extends Duplex {
     * cipher.update() after cipher.final() will result in an error being thrown.
     * @example cipher.update(data[, input_encoding][, output_encoding])
     */
-  def update(data: String, input_encoding: String, output_encoding: String = null): Unit = js.native
+  def update(data: String, input_encoding: String, output_encoding: String = null): js.Any = js.native
 
   /**
     * Updates the cipher with data. If the input_encoding argument is given, it's value must be one of 'utf8', 'ascii',

--- a/nodejs/src/main/scala/io/scalajs/nodejs/crypto/Crypto.scala
+++ b/nodejs/src/main/scala/io/scalajs/nodejs/crypto/Crypto.scala
@@ -130,4 +130,20 @@ class Crypto extends js.Object {
     */
   def getCiphers(): js.Array[String] = js.native
 
+  /**
+    * Provides a synchronous Password-Based Key Derivation Function 2 (PBKDF2) implementation. A selected HMAC digest
+    * algorithm specified by digest is applied to derive a key of the requested byte length (keylen) from the password,
+    * salt and iterations.
+    *
+    * If an error occurs an Error will be thrown, otherwise the derived key will be returned as a Buffer.
+    *
+    * The iterations argument must be a number set as high as possible. The higher the number of iterations, the more
+    * secure the derived key will be, but will take a longer amount of time to complete.
+    *
+    * The salt should also be as unique as possible. It is recommended that the salts are random and their lengths are
+    * greater than 16 bytes. See NIST SP 800-132 for details.
+    *
+    * (Doc source: https://nodejs.org/api/crypto.html#crypto_crypto_pbkdf2sync_password_salt_iterations_keylen_digest)
+    */
+  def pbkdf2Sync(password: String, salt: String, iterations: Int, keylen: Int, digest: String): Buffer = js.native
 }

--- a/nodejs/src/main/scala/io/scalajs/nodejs/crypto/Decipher.scala
+++ b/nodejs/src/main/scala/io/scalajs/nodejs/crypto/Decipher.scala
@@ -68,7 +68,7 @@ trait Decipher extends Duplex {
     * Calling decipher.update() after decipher.final() will result in an error being thrown.
     * @example decipher.update(data[, input_encoding][, output_encoding])
     */
-  def update(data: String, input_encoding: String, output_encoding: String = null): Unit = js.native
+  def update(data: String, input_encoding: String, output_encoding: String = null): js.Any = js.native
 
   /**
     * Updates the decipher with data. If the input_encoding argument is given, it's value must be one of 'binary',

--- a/nodejs/src/test/scala/io/scalajs/nodejs/crypto/CryptoTest.scala
+++ b/nodejs/src/test/scala/io/scalajs/nodejs/crypto/CryptoTest.scala
@@ -1,12 +1,12 @@
 package io.scalajs.nodejs.crypto
 
-import org.scalatest.FunSpec
+import org.scalatest.{FunSpec, MustMatchers}
 
 /**
   * Crypto Test
   * @author lawrence.daniels@gmail.com
   */
-class CryptoTest extends FunSpec {
+class CryptoTest extends FunSpec with MustMatchers {
 
   describe("Crypto") {
 
@@ -24,6 +24,32 @@ class CryptoTest extends FunSpec {
       hasher.update(text)
       val buffer = hasher.digest()
       assert(buffer.toHexString == "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e")
+    }
+
+    it("should be able to hash passwords with pbkdf2Sync") {
+      val computedHash =
+        Crypto.pbkdf2Sync("this-is-a-password", "random-salt", 10000, 512, "sha512").toString("base64")
+      val expectedHash =
+        "nzaxkuDuglFxKDMtr566d1mlr7kZV5y1j5PWpU9E/R9cpZz5q8pyYgeuTWADj2DhBF6koAsikPOac81lOHgK+tgiIYy6YRBd0SylsewT3QR5CelagTY1nrKougkJi95TmyKplJIO9M2szDqMhX5eT0yY2eVLnv9R0SCjd3qunvbVJmOvfEOgetPCwu5oUfRGeX/2JUlE6g3l80b252tVhzKUATeFMAKKdl448FzYdt/vWJRq2dt1ActjDV/C9RpWMNHBw10cLS3/ivSVXnjNzANArDSOAdzIh2lnrauoEtIULqlKFImx4vk2B7Pt4Wg5+ouOGWbW8ZeU1zOqAQOlDSOggxEs+fOJvOrFZdVwyZ15UYX2gRnHc+aNT2gQd+HKwCJMrDbuxz9rYQe7SGfcgeT6vxz2ZLnZ2E5SIWP5QIhm+CboYypDCGh7O5FwBHoJCSEJW3mFu/pA01Hwz11ORS6UeD/z29k546YZRa0jrzD5dLJQE+Rc72cVJv05VLs+U30b4NHcmmjmdqoT/vfxto9XM+atN7D10+dNne59YmbL9TQyvDBnxwHIUoXXGDp5OLjjtlh2A/AFu4VtF/vhRolyvSnMfQznJnEBmDkIiW/V1qwI0TevOheG04ERHtFU5eGUYt7ofPAlkUrrJxEmuwSyVoApuI+lI5CaKD4dke0="
+
+      computedHash mustEqual expectedHash
+    }
+
+    it("should be able to encrypt and decrypt text from a private key (AES-265-ctr)") {
+      val alg             = "aes-256-ctr"
+      val key             = "this-is-a-private-key"
+      val stringToEncrypt = "text-to-encrypt"
+
+      val cipher              = Crypto.createCipher(alg, key)
+      val encrypted           = cipher.update(stringToEncrypt, "utf8", "base64")
+      val finalEncryptedValue = encrypted + cipher.`final`("base64").asInstanceOf[String]
+
+      val decipher            = Crypto.createDecipher(alg, key)
+      val decrypted           = decipher.update(finalEncryptedValue, "base64", "utf8")
+      val finalDecryptedValue = decrypted + decipher.`final`("utf8").asInstanceOf[String]
+
+      finalEncryptedValue mustNot equal(stringToEncrypt)
+      finalDecryptedValue must equal(stringToEncrypt)
     }
 
   }


### PR DESCRIPTION
All updates have tests, had to run with `sbt "project nodejs" test` since my JVM falls over if I try to run the tests on the entire repo.