### PR TITLE
Update dependency and fix broken tests

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,3 @@
+version = "2.0.0-RC8"
 style = defaultWithAlign
 maxColumn = 120

--- a/app/current/src/test/scala/io/scalajs/nodejs/fs/FsTest.scala
+++ b/app/current/src/test/scala/io/scalajs/nodejs/fs/FsTest.scala
@@ -15,12 +15,12 @@ class FsTest extends FunSpec {
   describe("Fs") {
 
     it("supports watching files") {
-      val watcher = Fs.watch("./app/src/test/resources/", (eventType, file) => {
+      val watcher = Fs.watch("./app/current/src/test/resources/", (eventType, file) => {
         info(s"watcher: eventType = '$eventType' file = '$file'")
       })
       info(s"watcher: ${Util.inspect(watcher)}")
 
-      setImmediate(() => Fs.writeFile("./app/src/test/resources/1.txt", "Hello", error => {
+      setImmediate(() => Fs.writeFile("./app/current/src/test/resources/1.txt", "Hello", error => {
         if (isDefined(error)) {
           alert(s"error: ${JSON.stringify(error)}")
         }
@@ -28,9 +28,9 @@ class FsTest extends FunSpec {
     }
 
     it("should stream data") {
-      val file1 = "./app/src/test/resources/fileA1.txt"
-      val file2 = "./app/src/test/resources/fileA2.txt"
-      val file3 = "./app/src/test/resources/fileC2.txt"
+      val file1 = "./app/current/src/test/resources/fileA1.txt"
+      val file2 = "./app/current/src/test/resources/fileA2.txt"
+      val file3 = "./app/current/src/test/resources/fileC2.txt"
 
       val readable = Fs.createReadStream(file1)
       val writable = Fs.createWriteStream(file2)
@@ -55,8 +55,8 @@ class FsTest extends FunSpec {
     }
 
     it("should pipe data from a Readable to a Writable") {
-      val file1 = "./app/src/test/resources/fileB1.txt"
-      val file2 = "./app/src/test/resources/fileB2.txt"
+      val file1 = "./app/current/src/test/resources/fileB1.txt"
+      val file2 = "./app/current/src/test/resources/fileB2.txt"
 
       val readable = Fs.createReadStream(file1)
       val writable = Fs.createWriteStream(file2)

--- a/app/current/src/test/scala/io/scalajs/nodejs/url/URLSearchParamsTest.scala
+++ b/app/current/src/test/scala/io/scalajs/nodejs/url/URLSearchParamsTest.scala
@@ -28,7 +28,7 @@ class URLSearchParamsTest extends FunSpec {
         "query" -> js.Array("first", "second")
       ))
       info(params.getAll("query").mkString(", ")) // Prints [ "first,second" ]
-      assert(params.getAll("query") == js.Array("first,second"))
+      assert(params.getAll("query").toSeq == Seq("first,second"))
     }
 
     it("should iterates over each name-value pair in the query and invokes the given function") {

--- a/app/lts/src/test/scala/io/scalajs/nodejs/fs/FsTest.scala
+++ b/app/lts/src/test/scala/io/scalajs/nodejs/fs/FsTest.scala
@@ -15,12 +15,12 @@ class FsTest extends FunSpec {
   describe("Fs") {
 
     it("supports watching files") {
-      val watcher = Fs.watch("./app/src/test/resources/", (eventType, file) => {
+      val watcher = Fs.watch("./app/lts/src/test/resources/", (eventType, file) => {
         info(s"watcher: eventType = '$eventType' file = '$file'")
       })
       info(s"watcher: ${Util.inspect(watcher)}")
 
-      setImmediate(() => Fs.writeFile("./app/src/test/resources/1.txt", "Hello", error => {
+      setImmediate(() => Fs.writeFile("./app/lts/src/test/resources/1.txt", "Hello", error => {
         if (isDefined(error)) {
           alert(s"error: ${JSON.stringify(error)}")
         }
@@ -28,9 +28,9 @@ class FsTest extends FunSpec {
     }
 
     it("should stream data") {
-      val file1 = "./app/src/test/resources/fileA1.txt"
-      val file2 = "./app/src/test/resources/fileA2.txt"
-      val file3 = "./app/src/test/resources/fileC2.txt"
+      val file1 = "./app/lts/src/test/resources/fileA1.txt"
+      val file2 = "./app/lts/src/test/resources/fileA2.txt"
+      val file3 = "./app/lts/src/test/resources/fileC2.txt"
 
       val readable = Fs.createReadStream(file1)
       val writable = Fs.createWriteStream(file2)
@@ -55,8 +55,8 @@ class FsTest extends FunSpec {
     }
 
     it("should pipe data from a Readable to a Writable") {
-      val file1 = "./app/src/test/resources/fileB1.txt"
-      val file2 = "./app/src/test/resources/fileB2.txt"
+      val file1 = "./app/lts/src/test/resources/fileB1.txt"
+      val file2 = "./app/lts/src/test/resources/fileB2.txt"
 
       val readable = Fs.createReadStream(file1)
       val writable = Fs.createWriteStream(file2)

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,13 @@ import scala.language.postfixOps
 
 val scalaJsIOVersion = "0.4.3"
 val apiVersion = scalaJsIOVersion
-val scalaJsVersion = "2.12.8"
+
+
+val scala212Version = "2.12.8"
+val scala213Version = "2.13.0"
+val scalaJsVersion = scala212Version
+val supportedScalaVersions = Seq(scala212Version, scala213Version)
+
 val scalatestVersion = "3.0.5"
 val scalacticVersion = "3.0.5"
 
@@ -22,6 +28,7 @@ lazy val root = (project in file(".")).
     description := "NodeJS build artifact",
     homepage := Some(url("https://github.com/scalajs-io/nodejs")),
     scalaVersion := scalaJsVersion,
+    crossScalaVersions := supportedScalaVersions,
     scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:implicitConversions", "-Xlint"),
     scalacOptions += "-P:scalajs:sjsDefinedByDefault",
     scalacOptions in(Compile, doc) ++= Seq("-no-link-warnings"),
@@ -45,6 +52,7 @@ lazy val common = (project in file("./app/common")).
     description := "NodeJS common API",
     homepage := Some(url("https://github.com/scalajs-io/nodejs")),
     scalaVersion := scalaJsVersion,
+    crossScalaVersions := supportedScalaVersions,
     scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:implicitConversions", "-Xlint"),
     scalacOptions += "-P:scalajs:sjsDefinedByDefault",
     scalacOptions in(Compile, doc) ++= Seq("-no-link-warnings"),
@@ -69,6 +77,7 @@ lazy val current = (project in file("./app/current")).
     description := "NodeJS v8.7.0 API for Scala.js",
     homepage := Some(url("https://github.com/scalajs-io/nodejs")),
     scalaVersion := scalaJsVersion,
+    crossScalaVersions := supportedScalaVersions,
     scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:implicitConversions", "-Xlint"),
     scalacOptions += "-P:scalajs:sjsDefinedByDefault",
     scalacOptions in(Compile, doc) ++= Seq("-no-link-warnings"),
@@ -92,6 +101,7 @@ lazy val lts = (project in file("./app/lts")).
     description := "NodeJS LTS v6.11.4 API for Scala.js",
     homepage := Some(url("https://github.com/scalajs-io/nodejs")),
     scalaVersion := scalaJsVersion,
+    crossScalaVersions := supportedScalaVersions,
     scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:implicitConversions", "-Xlint"),
     scalacOptions += "-P:scalajs:sjsDefinedByDefault",
     scalacOptions in(Compile, doc) ++= Seq("-no-link-warnings"),

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,9 @@ import scala.language.postfixOps
 
 val scalaJsIOVersion = "0.4.3"
 val apiVersion = scalaJsIOVersion
-val scalaJsVersion = "2.12.3"
+val scalaJsVersion = "2.12.8"
+val scalatestVersion = "3.0.5"
+val scalacticVersion = "3.0.5"
 
 lazy val root = (project in file(".")).
   aggregate(common, current, lts).
@@ -29,8 +31,8 @@ lazy val root = (project in file(".")).
     logBuffered in Test := true,
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaJsVersion,
-      "org.scalactic" %% "scalactic" % "3.0.1",
-      "org.scalatest" %%% "scalatest" % "3.0.1" % "test",
+      "org.scalactic" %% "scalactic" % scalacticVersion,
+      "org.scalatest" %%% "scalatest" % scalatestVersion % "test",
       "io.scalajs" %%% "core" % scalaJsIOVersion
     ))
 
@@ -52,8 +54,8 @@ lazy val common = (project in file("./app/common")).
     logBuffered in Test := true,
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaJsVersion,
-      "org.scalactic" %% "scalactic" % "3.0.1",
-      "org.scalatest" %%% "scalatest" % "3.0.1" % "test",
+      "org.scalactic" %% "scalactic" % scalacticVersion,
+      "org.scalatest" %%% "scalatest" % scalatestVersion % "test",
       "io.scalajs" %%% "core" % scalaJsIOVersion
     ))
 
@@ -76,8 +78,8 @@ lazy val current = (project in file("./app/current")).
     logBuffered in Test := true,
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaJsVersion,
-      "org.scalactic" %% "scalactic" % "3.0.1",
-      "org.scalatest" %%% "scalatest" % "3.0.1" % "test"
+      "org.scalactic" %% "scalactic" % scalacticVersion,
+      "org.scalatest" %%% "scalatest" % scalatestVersion % "test"
     ))
 
 lazy val lts = (project in file("./app/lts")).

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.18

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.18
+sbt.version=1.3.0-RC2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 // Scala.js
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.27")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
 
 // Code Formatting
 
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.5.5")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.1")
 
 // Testing
 
@@ -14,7 +14,7 @@ addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.5.5")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
 
 // Resolvers
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 // Scala.js
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.20")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.27")
 
 // Code Formatting
 
@@ -12,9 +12,9 @@ addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.5.5")
 
 // Publishing
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 // Resolvers
 


### PR DESCRIPTION
* Update dependendecies to support newer ScalaJS and Java 11+.
* Fixes broken test

Note: This PR is tested on top of locally-published `scalajs-io/core` 0.4.3 from https://github.com/scalajs-io/core/pull/1

